### PR TITLE
ANAPI-29: Do not override shop filters

### DIFF
--- a/apps/anapi/src/anapi_handler_utils.erl
+++ b/apps/anapi/src/anapi_handler_utils.erl
@@ -140,3 +140,36 @@ validate_party_access(UserID, PartyID) when UserID =:= PartyID ->
 validate_party_access(_UserID, PartyID) ->
     % One day there will be a service for checking party accesss
     throw({invalidPartyID, PartyID}).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+-spec test() -> _.
+
+-spec enumerate_shop_ids_shopID_present_test() -> _.
+enumerate_shop_ids_shopID_present_test() ->
+    ShopID = <<"SHOP_ID">>,
+    Req = #{
+        'shopID' => ShopID
+    },
+    [ShopID] = enumerate_shop_ids(Req, #{}).
+
+-spec enumerate_shop_ids_shopIDs_present_test() -> _.
+enumerate_shop_ids_shopIDs_present_test() ->
+    ShopIDs = [<<"SHOP_ID">>, <<"SHOP_ID_2">>],
+    Req = #{
+        'shopIDs' => ShopIDs
+    },
+    ShopIDs = enumerate_shop_ids(Req, #{}).
+
+-spec enumerate_shop_ids_both_filters_present_test() -> _.
+enumerate_shop_ids_both_filters_present_test() ->
+    ShopID = <<"SHOP_ID">>,
+    ShopIDs = [<<"SHOP_ID_2">>, <<"SHOP_ID_3">>],
+    Req = #{
+        'shopID'  => ShopID,
+        'shopIDs' => ShopIDs
+    },
+    [ShopID | ShopIDs] = enumerate_shop_ids(Req, #{}).
+
+-endif.

--- a/apps/anapi/src/anapi_handler_utils.erl
+++ b/apps/anapi/src/anapi_handler_utils.erl
@@ -147,6 +147,7 @@ validate_party_access(_UserID, PartyID) ->
 -spec test() -> _.
 
 -spec enumerate_shop_ids_shopID_present_test() -> _.
+
 enumerate_shop_ids_shopID_present_test() ->
     ShopID = <<"SHOP_ID">>,
     Req = #{
@@ -167,7 +168,7 @@ enumerate_shop_ids_both_filters_present_test() ->
     ShopID = <<"SHOP_ID">>,
     ShopIDs = [<<"SHOP_ID_2">>, <<"SHOP_ID_3">>],
     Req = #{
-        'shopID'  => ShopID,
+        'shopID' => ShopID,
         'shopIDs' => ShopIDs
     },
     [ShopID | ShopIDs] = enumerate_shop_ids(Req, #{}).


### PR DESCRIPTION
Ошибка заключалась в том, что независимо от того был ли задан фильтр по магазинам, в поисковый критерий включались все магазины для данной `party`